### PR TITLE
Fixed bot not working after reboot

### DIFF
--- a/holderbot.sh
+++ b/holderbot.sh
@@ -139,4 +139,7 @@ nohup python3 monitoring.py & disown
 nohup python3 holder.py & disown
 nohup python3 expired.py & disown
 nohup python3 limiteder.py & disown
+chmod +x restart.sh
+{ crontab -l 2>/dev/null; echo "@reboot sleep 15 && /bin/bash /holderbot/restart.sh"; } | crontab -
+
 

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+HOME=/
+pkill -f monitoring.py 
+pkill -f holder.py 
+pkill -f expired.py 
+pkill -f limiteder.py 
+cd
+cd /holderbot
+source hold/bin/activate
+chmod +x monitoring.py
+chmod +x holder.py
+chmod +x expired.py
+chmod +x limiteder.py
+nohup python3 monitoring.py & disown
+nohup python3 holder.py & disown
+nohup python3 expired.py & disown
+nohup python3 limiteder.py & disown


### PR DESCRIPTION
added restart.sh for easy reboot of Holderbot and modified the holderbot.sh accordingly so it starts the bot on system startup